### PR TITLE
patch callback_url

### DIFF
--- a/lib/omniauth/avvo/version.rb
+++ b/lib/omniauth/avvo/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Avvo
-    VERSION = '0.0.4'
+    VERSION = '0.0.5'
   end
 end

--- a/lib/omniauth/strategies/avvo.rb
+++ b/lib/omniauth/strategies/avvo.rb
@@ -41,6 +41,10 @@ module OmniAuth
           user_data["user"] || {}
         end
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end


### PR DESCRIPTION
Omniauth's generic callback_url looks like this:

```
def callback_url
  full_host + script_name + callback_path + query_string
end
```

The oauth2 gem now passes extra query params which breaks avvo auth.   